### PR TITLE
Handle shadowing of bindings through macroexpansion

### DIFF
--- a/src/await_cps.clj
+++ b/src/await_cps.clj
@@ -95,7 +95,7 @@
   (let [r (gensym)
         e (gensym)]
    `(run-async (fn [~r ~e]
-                ~(invert {:r r :e e :terminators terminators}
+                ~(invert {:r r :e e :terminators terminators :env &env}
                          `(do ~@body)))
                ~resolve ~raise)))
 

--- a/src/await_cps/ioc.clj
+++ b/src/await_cps/ioc.clj
@@ -125,11 +125,13 @@
                             ~@body)))
 
             (has-terminators? body (dissoc ctx :recur-target))
-            (let [recur-target (gensym "recur")]
+            (let [recur-target (gensym "recur")
+                  updated-ctx (add-env-syms ctx bind-names)]
              `(letfn [(~recur-target [~@bind-names]
                         (loop [~@(interleave bind-names bind-names)]
-                         ~(invert (assoc ctx :sync-recur? true
-                                             :recur-target recur-target)
+                         ~(invert (assoc updated-ctx
+                                         :sync-recur? true
+                                         :recur-target recur-target)
                                  `(do ~@body))))]
                 (let [~@binds] (~recur-target ~@bind-names))))
 
@@ -166,7 +168,7 @@
                       (try (throw t#)
                        ~@(map (fn [[sym cls bnd & body]]
                                `(~sym ~cls ~bnd
-                                       ~(invert (assoc ctx :r fin :e finThrow)
+                                       ~(invert (assoc (add-env-syms ctx [bnd]) :r fin :e finThrow)
                                                `(do ~@body))))
                               catches))
                       (catch Throwable t# (~finThrow t#))))]

--- a/test/await_cps_test.clj
+++ b/test/await_cps_test.clj
@@ -205,6 +205,14 @@
                                        (b# [y# r# e#] (async r# e# (await a# y#)))]
                                  (await b# 1)))))))
 
+(deftest shadowing-symbols
+  ;; Here we shadow the `await` macro with a local function
+  (is (= 1 (:value (run-async timeout `(let [~'await (constantly 1)]
+                                         (~'await (fn [r# e#] (r# 2))))))))
+  ;; Here we shadow the `and` macro with a local function
+  (is (= 1 (:value (run-async timeout `(let [~'and (constantly 1)]
+                                         (~'and (await (fn [r# e#] (r# 2))))))))))
+
 (def ^:dynamic dynamic-var :globally-bound)
 
 (defn some-async [v r e]

--- a/test/await_cps_test.clj
+++ b/test/await_cps_test.clj
@@ -206,12 +206,13 @@
                                  (await b# 1)))))))
 
 (deftest shadowing-symbols
-  ;; Here we shadow the `await` macro with a local function
-  (is (= 1 (:value (run-async timeout `(let [~'await (constantly 1)]
-                                         (~'await (fn [r# e#] (r# 2))))))))
-  ;; Here we shadow the `and` macro with a local function
-  (is (= 1 (:value (run-async timeout `(let [~'and (constantly 1)]
-                                         (~'and (await (fn [r# e#] (r# 2))))))))))
+  (binding [*ns* (find-ns 'await-cps-test)]
+    ;; Here we shadow the `await` macro with a local function
+    (is (= 1 (:value (run-async timeout `(let [~'await (constantly 1)]
+                                           (~'await (fn [r# e#] (r# 2))))))))
+    ;; Here we shadow the `and` macro with a local function
+    (is (= 1 (:value (run-async timeout `(let [~'and (constantly 1)]
+                                           (~'and (await (fn [r# e#] (r# 2)))))))))))
 
 (def ^:dynamic dynamic-var :globally-bound)
 

--- a/test/await_cps_test.clj
+++ b/test/await_cps_test.clj
@@ -212,7 +212,19 @@
                                            (~'await (fn [r# e#] (r# 2))))))))
     ;; Here we shadow the `and` macro with a local function
     (is (= 1 (:value (run-async timeout `(let [~'and (constantly 1)]
-                                           (~'and (await (fn [r# e#] (r# 2)))))))))))
+                                           (~'and (await (fn [r# e#] (r# 2)))))))))
+    ;; Here we use `letfn` to introduce the binding
+    (is (= 1 (:value (run-async timeout `(letfn [(~'await [x#] 1)]
+                                           (~'await (fn [r# e#] (r# 2))))))))
+    ;; Here we use `loop` to introduce the binding
+    (is (= 1 (:value (run-async timeout `(loop [~'await (constantly 1)]
+                                           (~'await (fn [r# e#] (r# 2))))))))
+    ;; Here we use `catch` to introduce the binding
+    (is (thrown? ClassCastException ;; can't call Exception as function
+                 (:exception (run-async timeout `(try
+                                                   (throw (Exception.))
+                                                   (catch Exception ~'await
+                                                     (~'await (fn [r# e#] (r# 1)))))))))))
 
 (def ^:dynamic dynamic-var :globally-bound)
 


### PR DESCRIPTION
I've added two test cases to show the type of expansion that breaks without this change. The crux of it is that we need to provide an environment to `macroexpand`, but it doesn't let us do so. To get it to work we cheat a bit and invoke the macro function itself in [approximately the same way as Compiler.java](https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/Compiler.java#L6992-L6993) does.