### PR TITLE
Promote asynchronous functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,109 +1,157 @@
 # await-cps
 
-async/await for continuation-passing style functions
+async/await syntax for continuation-passing style functions
 
 [![Latest version on Clojars](https://clojars.org/await-cps/latest-version.svg)](https://clojars.org/await-cps)
 
-Continuation-passing style ([CPS](https://en.wikipedia.org/wiki/Continuation-passing_style))
-is a pattern where a function, instead of returning a value, calls the provided
-continuation function with that value. It's used in popular Clojure libraries
-([Ring's async handlers](https://github.com/ring-clojure/ring/wiki/Concepts#handlers),
-[clj-http](https://github.com/dakrone/clj-http#async-http-request))
-to avoid blocking the calling thread by long-running IO operations.
+Continuation-passing style
+([CPS](https://en.wikipedia.org/wiki/Continuation-passing_style))
+is a pattern where a function takes an extra 'continuation' argument
+(a callback) and invokes it with
+the result instead of returning the value. In Clojure ecosystem a popular
+flavour of this is to take two continuations for successful and exceptional
+outcome. It is used by Ring for
+[asynchronous handlers](https://github.com/ring-clojure/ring/wiki/Concepts#handlers)
+and by clj-http for
+[asynchronous responses](https://github.com/dakrone/clj-http#async-http-request)
+with the goal of avoiding blocking of the calling thread with long-running
+IO operations.
 
 Writing correct CPS code is awkward and
 [hard to get right](#how-is-writing-correct-cps-code-by-hand-hard) however.
 Any non-trivial flow can quickly become unmanageable. This library delivers
-async/await expressions that let you write idiomatic, synchronous-looking code
+async/await syntax that lets you write idiomatic, synchronous-looking code
 while leveraging the power of asynchronous, continuation-passing style functions.
 
 [API Docs](https://cljdoc.org/d/await-cps/await-cps/CURRENT/api/await-cps)
 
 ## Usage
 
-`await` the execution of asynchronous function in an `async` block just like
-it was a blocking function call.
-
 ```clojure
-(require '[await-cps :refer [async await]]
-         '[clj-http.client :as http])
+(require '[await-cps :refer [defn-async fn-async await await!]]
+         '[clj-http.client :as http]
+         'cheshire.core) ; required for :as :json
 
-(defn star-wars-greeting-handler [request respond raise]
-  ; initiate the async block
-  (async respond raise
-    (let [person-url (str "https://swapi.co/api/people/" (:id (:params request)))
-          ; await the completion of asynchronous http request, doesn't block the thread 
-          person (:body (await http/get person-url {:async? true :as :json}))]
-      (str "Hi! I'm " (:name person) " from "
-           ; await expression can go wherever a function call is allowed
-           (get-in (await http/get (:homeworld person) {:async? true :as :json})
-                   [:body :name])))))
-```
+; a naive, hand-crafted CPS function could look like this
+(defn star-wars-greeting [person-id resolve raise]
+  (let [person-url (str "https://swapi.co/api/people/" person-id)]
+    ; clj-http.client/get with {:async? true} is an example of a CPS function
+    (http/get person-url {:async? true :as :json}
+              (fn [result]
+                (let [person (:body result)]
+                  ; it gets awkward pretty quick with nested calls
+                  ; also, unhandled http/get exceptions are swallowed
+                  (http/get (:homeworld person) {:async? true :as :json}
+                            (fn [result]
+                              (resolve (str "Hi! I'm "
+                                            (:name person)
+                                            " from "
+                                            (get-in result [:body :name]))))
+                            raise)))
+              raise)))
 
-Use `defn-async` for brevity.
-
-```clojure
-(defn-async star-wars-greeting-handler [request]
-  (let [person-url (str "https://swapi.co/api/people/" (:id (:params request)))
+; let's redefine it as an asynchronous function
+(defn-async star-wars-greeting
+  [person-id] ; continuation arguments are injected for you and invoked implicitly
+  (let [person-url (str "https://swapi.co/api/people/" person-id)
+                      ; await does not block the calling thread
         person (:body (await http/get person-url {:async? true :as :json}))]
-    ...))
+    (str "Hi! I'm " (:name person) " from "
+                 ; you can put your awaits wherever you please
+         (get-in (await http/get (:homeworld person) {:async? true :as :json})
+                 [:body :name]))))
+
+; use await! to run it synchronously in the REPL
+(await! star-wars-greeting 1)
+;=> "Hi! I'm Luke Skywalker from Tatooine"
+
+; asynchronous functions are regular CPS functions
+(clojure.repl/doc star-wars-greeting)
+;=> user/star-wars-greeting
+;=> ([person-id &resolve &raise])
+
+; you can invoke them directly providing callbacks
+(star-wars-greeting 5
+  ; success callback takes the function result
+  println
+  ; failure callback takes the exception
+  #(println "Oops" (.getMessage %)))
+;=> nil
+; notice that the result arrives asynchronously
+;=> "Hi! I'm Leia Organa from Alderaan"
+
+; afn defines an inline asynchronous function
+(await! (fn-async []
+          (str "RRWWWGG => "
+               ; asynchronous functions are CPS and so awaitable
+               (await star-wars-greeting 13))))
+;=> "RRWWWGG => Hi! I'm Chewbacca from Kashyyyk"
+
+; asynchronous functions of one argument are valid Ring async handlers
+(defn-async star-wars-greeting-handler
+  [request] ; expands to [request respond raise]
+  (if-let [person-id (get-in request [:params :id])]
+    {:status 200 :body (await star-wars-greeting person-id)}
+    {:status 400 :body "id parameter required"}))
 ```
 
-### Asynchronous functions
+### await
 
-Asynchronous function is any function that takes `resolve` and `raise` callbacks
-as the last two parameters. It is expected to evetually either call `resolve`
-with the result value, call `raise` with a `Throwable` or throw in the calling
-thread. The return value is ignored.
+`await` works within the scope of an asynchronou function defined with
+`defn-async` and `fn-async`. Although it's not technically a function you can
+place it wherever a function call is syntactically allowed. It executes the CPS
+function along with any arguments provided plus two generated continuations.
+The continuations are generated based on the surrounding code to create the
+illusion of `await` blocking the flow.
 
-You can await the completion of asynchronous function in an `async` block
-calling `await` with the function and any parameters, leaving the callbacks
-out. You're free to use await wherever a function call is allowed.
-The execution does not block the calling thread, resuming in whatever
-thread the awaited function invokes the callback in instead. Awaiting will
-observe the resolved value as if it was returned or any exception thrown or
-raised as if it was thrown.
+It does not block the calling thread however. The control is passed to the CPS
+function and the execution continues in the thread continuation is invoked in.
 
-### Asynchronous block boundary
+Awaitable CPS functions are expected to take two continuation functions as
+their last parameters and eventually invoke one of them. It is acceptable for
+a CPS function to throw in the calling thread. The return value of both,
+the CPS function and the continuation is ignored. The second, exceptional
+continuation only accepts a `Throwable`.
 
-`async` body can handle arbitrary Clojure code. Its boundary does not stretch
-inside nested `def`s nor the body of any nested function however.
-This includes `def`, `fn`, `reify`, `deftype` and functions in `letfn`.
-The code below does *not* work:
+Asynchronous functions produced by `defn-async` and `fn-async` are always
+awaitable.
+
+### Asynchronous function's boundary
+
+Functions defined inside an asynchronous function cannot be implicitly made
+asynchronous themselves. `await` won't work in any nested `fn`, `reify`, `def`,
+`deftype` or a function bound in `letfn`.
 
 ```clojure
-(async resolve raise
-  (doall (map (fn [url] (await http/get url {:async true}))
-              ["https://google.com" "https://twitter.com"])))
-=> IllegalStateException await called outside async block
+(await! (fn-async []
+          (doall (map (fn [url] (:status (await http/get url {:async true})))
+                      ["https://google.com" "https://twitter.com"]))))
+;=> IllegalStateException await called outside async block
+
+; use loop/recur to traverse collections
+; or doseq if you're traversing for side effects only
+
+(await! (fn-async []
+          (loop [[url & urls] ["https://google.com" "https://twitter.com"]
+                 statuses []]
+            (if url
+              (recur urls (conj statuses (:status (await http/get url {:async? true}))))
+              statuses))))
+;=> [200 200]
 ```
 
-Use `loop/recur` to traverse collections.
+### recur
+
+Recurring a `fn-async` or `defn-async` function the implicit continuation
+arguments are omitted.
 
 ```clojure
-(async resolve raise
-  (loop [[url & urls] ["https://google.com" "https://twitter.com"]]
-    (when url
-      (println (:body (await http/get url {:async? true})))
-      (recur urls))))
+(await! (fn-async [[url & urls]]
+          (when url
+            (println url (:status (await http/get url {:async? true})))
+            (recur urls)))
+        ["https://google.com" "https://twitter.com"])
 ```
-
-You can also use `fn-async` for ad-hoc asynchronous functions.
-
-```clojure
-(async resolve raise
-  (loop [[f & fs] (map (fn [url] (fn-async []
-                                   (:body (await http/get url {:async? true}))))
-                       ["https://google.com" "https://twitter.com"])]
-    (when f
-      (println (await f))
-      (recur fs))))
-```
-
-### Recurring
-
-Recurring is supported in the context of `fn-async`, `defn-async` and `loop`
-within `async` block.
 
 ### try/catch/finally
 
@@ -115,27 +163,28 @@ that's executing a regular `try` block.
 
 ### Monitor operations
 
-`monitor-enter` and `monitor-exit` (and by extension the `locking` macro)
-are JVM's low level concurrency primitives strictly bound to executing thread
-and therefore are not supported in `async` blocks.
-Used across asynchronous call will lead to concurrency bugs.
+`monitor-enter` and `monitor-exit` are JVM's low level concurrency primitives
+strictly bound to the executing thread and are not supported in asynchronous
+functions (and as a consequence neither is the `locking` macro).
+
+Used across asynchronous calls will lead to concurrency bugs.
 Currently there's no warning if this is to happen.
 
 ## Does it work?
 
 Being cautious about third-party software applying chainsaw surgery to your
-production code is only fair. The goal of this library is for you to be able
+production code is only fair. A goal of this library is for you to be able
 to use it with confidence.
 
 The test suite included employs generative testing producing nested combinations
 of expressions, including special forms, synchronous and asynchronous function
-calls, failures and side-effects.
+calls, exceptions and side-effects.
 It asserts that both the result (value returned or exception thrown) and
 the order of any side-effects is consistent with what you'd observe executing
 synchronously in a single thread.
 
-At the same time, the project has not seen extensive production use yet,
-use with caution. Please, raise any issues through
+At the same time, the project has not seen extensive production use yet.
+Use with caution. Please, raise any issues through
 [GitHub](https://github.com/mszajna/await-cps/issues).
 
 ## How is writing correct CPS code by hand hard?
@@ -154,7 +203,7 @@ calling `raise`
 ### Equivalent for try/catch/finally
 
 Writing correct CPS equivalent for `try/catch/finally` block is about
-the trickiest problem this library solves. It needs to:
+the trickiest problem this library tackles. It needs to:
 - handle all 3 exit modes of asynchronous function (exception thrown,
   resolve called, raise called)
 - correctly scope the try/catch block outside the asynchronous function as well

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ while leveraging the power of asynchronous, continuation-passing style functions
 ## Usage
 
 ```clojure
-(require '[await-cps :refer [defn-async fn-async await await!]]
+(require '[await-cps :refer [defn-async afn await await!]]
          '[clj-http.client :as http]
          'cheshire.core) ; required for :as :json
 
@@ -81,7 +81,7 @@ while leveraging the power of asynchronous, continuation-passing style functions
 ;=> "Hi! I'm Leia Organa from Alderaan"
 
 ; afn defines an inline asynchronous function
-(await! (fn-async []
+(await! (afn []
           (str "RRWWWGG => "
                ; asynchronous functions are CPS and so awaitable
                (await star-wars-greeting 13))))
@@ -97,9 +97,9 @@ while leveraging the power of asynchronous, continuation-passing style functions
 
 ### await
 
-`await` works within the scope of an asynchronou function defined with
-`defn-async` and `fn-async`. Although it's not technically a function you can
-place it wherever a function call is syntactically allowed. It executes the CPS
+`await` works within the scope of an asynchronous function defined with
+`defn-async` and `afn`. Although it's not technically a function you can place
+it wherever a function call is syntactically allowed. It executes the CPS
 function along with any arguments provided plus two generated continuations.
 The continuations are generated based on the surrounding code to create the
 illusion of `await` blocking the flow.
@@ -113,8 +113,7 @@ a CPS function to throw in the calling thread. The return value of both,
 the CPS function and the continuation is ignored. The second, exceptional
 continuation only accepts a `Throwable`.
 
-Asynchronous functions produced by `defn-async` and `fn-async` are always
-awaitable.
+Asynchronous functions produced by `defn-async` and `afn` are always awaitable.
 
 ### Asynchronous function's boundary
 
@@ -123,7 +122,7 @@ asynchronous themselves. `await` won't work in any nested `fn`, `reify`, `def`,
 `deftype` or a function bound in `letfn`.
 
 ```clojure
-(await! (fn-async []
+(await! (afn []
           (doall (map (fn [url] (:status (await http/get url {:async true})))
                       ["https://google.com" "https://twitter.com"]))))
 ;=> IllegalStateException await called outside async block
@@ -131,7 +130,7 @@ asynchronous themselves. `await` won't work in any nested `fn`, `reify`, `def`,
 ; use loop/recur to traverse collections
 ; or doseq if you're traversing for side effects only
 
-(await! (fn-async []
+(await! (afn []
           (loop [[url & urls] ["https://google.com" "https://twitter.com"]
                  statuses []]
             (if url
@@ -142,11 +141,11 @@ asynchronous themselves. `await` won't work in any nested `fn`, `reify`, `def`,
 
 ### recur
 
-Recurring a `fn-async` or `defn-async` function the implicit continuation
-arguments are omitted.
+Recurring a `defn-async` or `afn` function, the implicit continuation arguments
+are omitted.
 
 ```clojure
-(await! (fn-async [[url & urls]]
+(await! (afn [[url & urls]]
           (when url
             (println url (:status (await http/get url {:async? true})))
             (recur urls)))

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,6 @@
 {:paths ["src"]
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}}}}}
+         :extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}}}
+  :readme {:extra-deps {clj-http {:mvn/version "3.10.0"}
+                        cheshire {:mvn/version "5.9.0"}}}}}

--- a/src/await_cps.clj
+++ b/src/await_cps.clj
@@ -94,7 +94,7 @@
                          `(do ~@body)))
                ~resolve ~raise)))
 
-(defmacro fn-async
+(defmacro afn
   "Defines an asynchronous function. Declared parameters are extended with two
    continuation arguments of &resolve and &raise and these continuations will
    be called with the function result or any exception thrown respectively.
@@ -113,6 +113,13 @@
         param-names (map #(if (symbol? %) % (gensym)) params)]
    `(fn ~@(when name [name]) [~@param-names ~'&resolve ~'&raise]
       (async ~'&resolve ~'&raise (loop [~@(interleave params param-names)] ~@body)))))
+
+(def
+ ^{:macro true
+   :deprecated "0.1.9"
+   :doc "Deprecated - renamed to afn."}
+  fn-async
+  #'afn)
 
 (defmacro defn-async
   "Same as defn but defines an asynchronous function with extra &resolve and

--- a/src/await_cps.clj
+++ b/src/await_cps.clj
@@ -74,11 +74,11 @@
   nil)
 
 (defn await
-  "Awaits asynchronous execution of continuation-passing style function f,
+  "Awaits asynchronous execution of continuation-passing style function cps-fn,
    applying it to args plus two extra callback functions: resolve and raise.
    Effectively returns the value passed to resolve or throws the exception
    passed to raise. Must be called in an asynchronous function."
-  [f & args]
+  [cps-fn & args]
   (throw (new IllegalStateException "await called outside asynchronous context")))
 
 (def ^:no-doc terminators

--- a/test/await_cps_test.clj
+++ b/test/await_cps_test.clj
@@ -4,7 +4,7 @@
             [clojure.test.check :refer [quick-check]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :refer [for-all]]
-            [await-cps :refer [async await fn-async defn-async]]
+            [await-cps :refer [async await afn defn-async]]
             [await-cps.ioc :refer [has-terminators?]]
             [await-cps.generators :as g]))
 
@@ -253,8 +253,8 @@
   (is (= #'value (:value (run-async timeout `(await value (var value)))))))
 
 (deftest test-fn-async
-  (is (= 1 (:value (run-async timeout `(await (fn-async [] (await value 1)))))))
-  (is (= 0 (:value (run-async timeout `(await (fn-async [a#]
+  (is (= 1 (:value (run-async timeout `(await (afn [] (await value 1)))))))
+  (is (= 0 (:value (run-async timeout `(await (afn [a#]
                                                 (if (> a# 0)
                                                     (recur (await async-return-immediate nil (dec a#))) a#))
                                               10000))))))


### PR DESCRIPTION
Renamed `fn-async` to `afn` (the previous name works but is deprecated).

Rephrased the README and doc strings to promote 'asynchronous functions' instead of 'asynchronous blocks'. The emphasis is placed on `defn-async` and `afn`. All mentions of `async` have been removed from the README as it's a construct that should be rarely needed.