### PR TITLE
Interop + Readme changes

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,8 @@
 {:paths ["src"]
  :aliases
  {:test {:extra-paths ["test"]
-         :extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}}}
+         :extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}
+                      org.clojure/core.async {:mvn/version "0.4.500"}
+                      manifold {:mvn/version "0.1.8"}}}
   :readme {:extra-deps {clj-http {:mvn/version "3.10.0"}
                         cheshire {:mvn/version "5.9.0"}}}}}

--- a/src/await_cps/java.clj
+++ b/src/await_cps/java.clj
@@ -1,0 +1,30 @@
+(ns await-cps.java
+  "Interoperability with Java 8 CompletableFuture."
+  (:refer-clojure :exclude [future-call])
+  (:import java.util.function.BiFunction
+           java.util.concurrent.CompletableFuture))
+
+(defn future-call
+  "Applies cps-fn to args plus two continuations that complete the
+   CompletableFuture returned successfully or exceptionally."
+  [cps-fn & args]
+  (let [cf (new CompletableFuture)
+        f (apply partial cps-fn args)
+        r #(.complete cf %)
+        e #(.completeExceptionally cf %)]
+    (try (f r e)
+      (catch Throwable t (e t)))
+    cf))
+
+(defn completed
+  "When the CompletableFuture is completed successfully calls resolve with the
+   value. If it's completed exceptionally calls raise with the exception.
+   Use with await: (await completed cf)"
+  [cf resolve raise]
+  (.handle
+    cf
+    (reify BiFunction
+      (apply [_ v t]
+        (if t
+          (raise t)
+          (resolve v))))))

--- a/test/await_cps/interop_test.clj
+++ b/test/await_cps/interop_test.clj
@@ -1,0 +1,54 @@
+(ns await-cps.interop-test
+  (:refer-clojure :exclude [await])
+  (:require [clojure.test :refer :all]
+            [await-cps :refer [afn await either-promise]]
+            [await-cps.java :as j]
+            [manifold.deferred :as d]
+            [clojure.core.async :as a])
+  (:import java.util.concurrent.CompletableFuture
+           java.util.concurrent.TimeUnit
+           java.util.concurrent.TimeoutException
+           java.util.concurrent.ExecutionException))
+
+(defn await-at-most! [ms cps-fn & args]
+  (let [p (apply either-promise cps-fn args)
+        [v t] (deref p ms [nil (new TimeoutException)])]
+    (if t (throw t) v)))
+
+(deftest use-java-cf-in-async-function
+  (let [cf (new CompletableFuture)]
+    (.complete cf true)
+    (is (await-at-most! 200 (afn [] (await j/completed cf)))))
+  (let [cf (new CompletableFuture)]
+    (.completeExceptionally cf (ex-info "Success" {}))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Success"
+          (await-at-most! 200 (afn [] (await j/completed cf)))))))
+
+(deftest use-cps-with-java-cf
+  (let [cf (j/future-call (afn [] true))]
+    (is (deref cf 200 :timeout)))
+  (let [cf (j/future-call (afn [] (throw (ex-info "Success" {}))))]
+    (is (thrown-with-msg? ExecutionException #"Success"
+          (deref cf 200 :timeout)))))
+
+(deftest use-manifold-deferred-in-async-function
+  (let [d (d/success-deferred true)]
+    (is (await-at-most! 200 (afn [] (await d/on-realized d)))))
+  (let [d (d/error-deferred (ex-info "Success" {}))]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Success"
+          (await-at-most! 200 (afn [] (await d/on-realized d)))))))
+
+(deftest use-cps-with-manifold-deferred
+  (let [d (d/chain (j/future-call (afn [] true)))]
+    (is (deref d 200 :timeout)))
+  (let [d (d/chain (j/future-call (afn [] (throw (ex-info "Success" {})))))]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Success"
+          (deref d 200 :timeout)))))
+
+(deftest use-core-async-channel-in-async-function
+  (let [ch (a/chan 1)]
+    (is (await-at-most! 200
+          (afn [] (when (await a/put! ch true) (await a/take! ch))))))
+  (let [ch (a/chan)]
+    (is (nil? (await-at-most! 200
+                (afn [] (a/close! ch) (await a/take! ch)))))))

--- a/test/await_cps_test.clj
+++ b/test/await_cps_test.clj
@@ -38,7 +38,8 @@
             ~'respond #(deliver result# {:value %})
             ~'raise #(deliver result# {:exception %})
             ~@(mapcat #(vector % (str "undef-" %)) g/symbols)]
-        ~async-form
+        (try ~async-form
+          (catch clojure.lang.ExceptionInfo t# (~'raise t#)))
         (deref result# ~timeout {:timeout timeout})))))
 
 (defn run-async* [timeout async-form]


### PR DESCRIPTION
Added interoperability with blocking code.
Added interoperability namespace for Java 8 CompletableFuture.
Documented interoperability with Manifold, promesa and core.async.
Removed the handling of all exceptions thrown in callbacks. This is now responsibility of interop code.
Documented that user is expected not to throw in their callbacks.
Reduced the size of README using more concise wording and moving some topics to docstrings.