### PR TITLE
Macroexpand all

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
 {:paths ["src"]
+ :deps {riddley {:mvn/version "0.2.0"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}

--- a/src/await_cps.clj
+++ b/src/await_cps.clj
@@ -3,7 +3,8 @@
    callback in the last two arguments, a pattern known as continuation-passing
    style (CPS) and popularised by Ring and clj-http."
   (:refer-clojure :exclude [await bound-fn])
-  (:require [await-cps.ioc :refer [invert]]))
+  (:require [await-cps.ioc :refer [invert]]
+            [riddley.walk :refer [macroexpand-all]]))
 
 (defn ^:no-doc bound-fn
   [f]
@@ -82,7 +83,7 @@
         e (gensym)]
    `(letfn [(inverted# [~r ~e]
              ~(invert {:r r :e e :terminators terminators :env &env}
-                     `(do ~@body)))]
+                      (macroexpand-all `(do ~@body))))]
       (run-async inverted# ~resolve ~raise))))
 
 (defmacro afn

--- a/src/await_cps/ioc.clj
+++ b/src/await_cps/ioc.clj
@@ -11,7 +11,7 @@
   (let [sym (when (seq? form) (first form))]
     (cond (contains? terminators (var-name env sym)) true
           (and recur-target (= 'recur sym)) true
-          (= 'loop sym) (some #(has-terminators? % (dissoc ctx :recur-target)) (rest form))
+          (= 'loop* sym) (some #(has-terminators? % (dissoc ctx :recur-target)) (rest form))
           (coll? form) (some #(has-terminators? % ctx) form)
           :else false)))
 


### PR DESCRIPTION
Used [riddley](https://github.com/ztellman/riddley) to macroexpand the entire body of the async block to address #2 