### PR TITLE
Experimental support for ClojureScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .cpcache/
 target/
+.cljs_nashorn_repl/
+nashorn_code_cache/

--- a/src/await_cps.clj
+++ b/src/await_cps.clj
@@ -75,13 +75,18 @@
 (def ^:no-doc terminators
   {`await `do-await})
 
+(def ^:private cljs? (boolean (find-ns 'cljs.analyzer)))
+
 (defmacro async
   "Like ((afn [] body*) resolve raise)."
   [resolve raise & body]
   (let [r (gensym)
         e (gensym)]
    `(letfn [(inverted# [~r ~e]
-             ~(invert {:r r :e e :terminators terminators :env &env}
+             ~(invert {:r r :e e
+                       :terminators terminators
+                       :env &env
+                       :all-ex (if cljs? :default `Throwable)}
                      `(do ~@body)))]
       (run-async inverted# ~resolve ~raise))))
 

--- a/src/await_cps.cljs
+++ b/src/await_cps.cljs
@@ -1,0 +1,64 @@
+(ns await-cps
+  "async/await syntax for functions that take a successful- and an exceptional
+   callback in the last two arguments, a pattern known as continuation-passing
+   style (CPS) and popularised by Ring and clj-http."
+  (:refer-clojure :exclude [await bound-fn])
+  (:require-macros [await-cps]))
+
+(def ^:no-doc bound-fn identity)
+
+(defn ^:no-doc do-await
+  [r e f & args]
+  (let [state (atom [:start])
+        resolve (fn [v] (let [[[before r']]
+                              (swap-vals! state
+                                          #(case (first %)
+                                             :start [:resolved v]
+                                             :async [:completed]
+                                             %))]
+                          (when (= before :async) (r' v))))
+        raise (fn [t] (let [[[before _ e']]
+                            (swap-vals! state
+                                        #(case (first %)
+                                           :start [:raised t]
+                                           :async [:completed]
+                                           %))]
+                        (when (= before :async) (e' t))))]
+    (apply f (concat args [resolve raise]))
+    (let [run (bound-fn trampoline)
+          safe-r #(try (r %) (catch :default t (e t)))
+          other-thread-r #(run safe-r %)
+          other-thread-e #(run e %)
+          [[before x]]
+          (swap-vals! state
+                      #(case (first %)
+                         :start [:async other-thread-r other-thread-e]
+                         :resolved [:completed]
+                         :raised [:completed]
+                         %))]
+      (case before
+        :resolved (partial safe-r x)
+        :raised (partial e x)
+        nil))))
+
+(defn ^:no-doc run-async
+  [f resolve raise]
+  (let [run (bound-fn trampoline)]
+    (run f resolve raise)
+    nil))
+
+(defn await
+  "Awaits the asynchronous execution of continuation-passing style function
+   cps-fn, applying it to args and two extra callback functions: resolve and
+   raise. cps-fn is expected to eventually either call resolve with the result,
+   call raise with the exception or just throw in the calling thread. The
+   return value of cps-fn is ignored. Effectively returns the value passed to
+   resolve or throws the exception passed to raise (or thrown) but does not
+   block the calling tread.
+
+   Must be called in an asynchronous function. Note that any nested functions
+   defined with fn, letfn, reify or deftype are considered outside of
+   asynchronous scope."
+  [cps-fn & args]
+  (throw (new js/Error
+              "await called outside of asynchronous scope")))


### PR DESCRIPTION
Code generator now accepts the exception type as param.
Provided .cljs for await-cps namespace. This requires significant duplication (bar removed support for binding macro that CLJS handles differently).